### PR TITLE
docs: Mention the necessity of root permissions

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -48,6 +48,8 @@ Remoteproc Runtime supports several container engines, but the specifics of inte
 - **[Container Runtime (Podman)](#container-runtime-podman)** - For Podman deployments
 - **[Container Runtime (standalone)](#container-runtime-standalone)** - For direct OCI runtime usage
 
+Accessing and controlling remoteproc devices typically requires root permissions, as the driver interfaces are located in the /sys/class directory. To ensure Remoteproc Runtime has the necessary privileges, run your container engine (e.g., Docker daemon, K3S, or Podman) with root privileges (typically via `sudo`), so that it can spawn containers with Remoteproc Runtime running as root.
+
 ### Containerd Shim (Docker, K3s, etc)
 
 1. **Install the shim and runtime**


### PR DESCRIPTION
Remoteproc Runtime uses Remoteproc, which usually requires root permissions to write to its filesystem.

To ensure that Remoteproc Runtime has root access, the container engines that spawn containers with Remoteproc Runtime should be run with root access.

<!-- PR title should be formatted using conventional commits -->
<!-- https://www.conventionalcommits.org/en/v1.0.0/ -->
<!-- Example: feat: A very fancy feature -->

## Changes

<!-- List the changes this PR introduces -->

-

## Checklist

<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->

- [ ] 🤖 This change is covered by tests as required.
- [ ] 🤹 All required manual testing has been performed.
- [x] 📖 All documentation updates are complete.
