### PR TITLE
fix: set ExitedAt timestamp on all shim exit paths

### DIFF
--- a/internal/shim/service.go
+++ b/internal/shim/service.go
@@ -356,7 +356,10 @@ func (s *remoteprocTaskService) Wait(ctx context.Context, r *taskAPI.WaitRequest
 				return nil, err
 			}
 			if state.Status == specs.StateStopped {
-				response := &taskAPI.WaitResponse{ExitStatus: 0}
+				response := &taskAPI.WaitResponse{
+					ExitStatus: 0,
+					ExitedAt:   protobuf.ToTimestamp(time.Now().UTC()),
+				}
 				s.logPayload("<- service.Wait", response)
 				return response, nil
 			}

--- a/internal/shim/service.go
+++ b/internal/shim/service.go
@@ -406,6 +406,7 @@ func (s *remoteprocTaskService) startProcessWatcher(containerID string, pid int)
 				ContainerID: containerID,
 				ID:          containerID,
 				Pid:         uint32(pid),
+				ExitedAt:    protobuf.ToTimestamp(time.Now().UTC()),
 			})
 
 			s.shutdown.Shutdown()


### PR DESCRIPTION
## Summary

When a container's process is killed externally (bypassing `docker stop`), the shim reports the exit through two mechanisms — a `TaskExit` event and the `Wait` ttrpc response. Both were missing the `ExitedAt` field.

A nil protobuf timestamp deserializes to Unix epoch (`1970-01-01`), not Go's zero time (`0001-01-01`). Docker's `SetStopped` has a fallback that uses `time.Now()` when `ExitedAt.IsZero()` — but epoch is *not* `IsZero()`, so Docker stores epoch as `FinishedAt`. This causes the e2e assertion in `killing_process_by_pid_stops_the_running_container` to fail with a delta of ~500,000 hours.

The `Kill` and `Delete` methods already set `ExitedAt` correctly — only the process watcher (`TaskExit` event) and `Wait` response were affected.

On CI, a second exit event from containerd's `cleanupAfterDeadShim` (which calls `manager.Stop` → `time.Now()`) races with the shim's original event, masking the bug most of the time. On a Lima VM the original event tends to win, making the failure consistent locally.